### PR TITLE
fix implimentation smells for CsvEncoder, YAMLGenerator and StringQuo…

### DIFF
--- a/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/impl/CsvEncoder.java
+++ b/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/impl/CsvEncoder.java
@@ -553,21 +553,8 @@ public class CsvEncoder
     public void endRow() throws IOException
     {
         // First things first; any buffered?
-        if (_lastBuffered >= 0) {
-            final int last = _lastBuffered;
-            _lastBuffered = -1;
-            for (; _nextColumnToWrite <= last; ++_nextColumnToWrite) {
-                BufferedValue value = _buffered[_nextColumnToWrite];
-                if (value != null) {
-                    _buffered[_nextColumnToWrite] = null;
-                    value.write(this);
-                } else if (_nextColumnToWrite > 0) { // ) {
-                    // note: write method triggers prepending of separator; but for missing
-                    // values we need to do it explicitly.
-                    appendColumnSeparator();
-                } 
-            }
-        } else if (_nextColumnToWrite <= 0) { // empty line; do nothing
+        handleBufferedValues();
+        if (_nextColumnToWrite <= 0) { // empty line; do nothing
             return;
         }
         // Any missing values?
@@ -585,6 +572,25 @@ public class CsvEncoder
         }
         System.arraycopy(_cfgLineSeparator, 0, _outputBuffer, _outputTail, _cfgLineSeparatorLength);
         _outputTail += _cfgLineSeparatorLength;
+    }
+
+    private void handleBufferedValues() throws IOException {
+        if (_lastBuffered < 0) {
+            return;
+        }
+
+        final int last = _lastBuffered;
+        _lastBuffered = -1;
+
+        for (; _nextColumnToWrite <= last; ++_nextColumnToWrite) {
+            BufferedValue value = _buffered[_nextColumnToWrite];
+            if (value != null) {
+                _buffered[_nextColumnToWrite] = null;
+                value.write(this);
+            } else if (_nextColumnToWrite > 0) {
+                appendColumnSeparator();
+            }
+        }
     }
 
     /*

--- a/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLGenerator.java
+++ b/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLGenerator.java
@@ -653,8 +653,7 @@ public class YAMLGenerator extends GeneratorBase
      */
 
     @Override
-    public void writeString(String text) throws IOException,JsonGenerationException
-    {
+    public void writeString(String text) throws IOException, JsonGenerationException {
         if (text == null) {
             writeNull();
             return;
@@ -666,27 +665,31 @@ public class YAMLGenerator extends GeneratorBase
             _writeScalar(text, "string", STYLE_QUOTED);
             return;
         }
+
         DumperOptions.ScalarStyle style;
-        if (Feature.MINIMIZE_QUOTES.enabledIn(_formatFeatures)) {
-            if (text.indexOf('\n') >= 0) {
+        boolean hasNewline = text.indexOf('\n') >= 0;
+        boolean minimizeQuotes = Feature.MINIMIZE_QUOTES.enabledIn(_formatFeatures);
+        boolean literalBlockStyle = Feature.LITERAL_BLOCK_STYLE.enabledIn(_formatFeatures);
+        boolean alwaysQuoteNumbers = Feature.ALWAYS_QUOTE_NUMBERS_AS_STRINGS.enabledIn(_formatFeatures);
+
+        if (minimizeQuotes) {
+            if (hasNewline) {
                 style = STYLE_LITERAL;
-            // If one of reserved values ("true", "null"), or, number, preserve quoting:
-            } else if (_quotingChecker.needToQuoteValue(text)
-                || (Feature.ALWAYS_QUOTE_NUMBERS_AS_STRINGS.enabledIn(_formatFeatures)
-                        && PLAIN_NUMBER_P.matcher(text).matches())
-                ) {
+            } else if (_quotingChecker.needToQuoteValue(text)) {
+                style = STYLE_QUOTED;
+            } else if (alwaysQuoteNumbers && PLAIN_NUMBER_P.matcher(text).matches()) {
                 style = STYLE_QUOTED;
             } else {
                 style = STYLE_PLAIN;
             }
         } else {
-            if (Feature.LITERAL_BLOCK_STYLE.enabledIn(_formatFeatures)
-                    && text.indexOf('\n') >= 0) {
+            if (literalBlockStyle && hasNewline) {
                 style = STYLE_LITERAL;
             } else {
                 style = STYLE_QUOTED;
             }
         }
+
         _writeScalar(text, "string", style);
     }
 

--- a/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/util/StringQuotingChecker.java
+++ b/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/util/StringQuotingChecker.java
@@ -17,6 +17,7 @@ public abstract class StringQuotingChecker
     implements java.io.Serializable
 {
     private static final long serialVersionUID = 1L;
+    private static final int SPACE_CODE_POINT = 0x0020;
 
     /**
      * As per YAML <a href="https://yaml.org/type/null.html">null</a>
@@ -194,7 +195,7 @@ public abstract class StringQuotingChecker
         final int end = inputStr.length();
         for (int i = 0; i < end; ++i) {
             int ch = inputStr.charAt(i);
-            if (ch < 0x0020) {
+            if (ch < SPACE_CODE_POINT) {
                 return true;
             }
         }


### PR DESCRIPTION
Fixed following implementation smells:

- Magic Number (in `StringQuotingChecker.nameHasQuotableChar()`)
- Complex Method (in `CsvEncoder.endRow()`)
- Complex Conditional (in `YAMLGenerator.writeString()`)

Checklist:

- [x] Is the project building?
- [x] Are all existing test cases passing?